### PR TITLE
Added dynamic reconfigure, auto white balance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,21 +15,27 @@ set(
      roscpp
      roslaunch
      sensor_msgs
-     #std_srvs
      nodelet
+     dynamic_reconfigure
+     roslint
 )
 
 find_package(Pylon QUIET)
 if (NOT ${Pylon_FOUND})
     include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindPylon.cmake")
 endif()
+
 find_package(
     catkin REQUIRED
     COMPONENTS
      ${CATKIN_COMPONENTS}
-     #std_srvs
-     roslint
 )
+
+catkin_python_setup()
+generate_dynamic_reconfigure_options(
+  cfg/CameraSettings.cfg
+)
+
 
 catkin_package(
     INCLUDE_DIRS
@@ -123,7 +129,10 @@ add_dependencies(
      ${catkin_EXPORTED_TARGETS}
 )
 
-catkin_python_setup()
+add_dependencies(
+    ${PROJECT_NAME}_node
+    ${PROJECT_NAME}_gencfg 
+)
 
 install(
     DIRECTORY

--- a/cfg/CameraSettings.cfg
+++ b/cfg/CameraSettings.cfg
@@ -5,6 +5,16 @@ PACKAGE = "pylon_camera"
 from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
-gen.add("whitebalance_auto", bool_t, 0, "auto white balance toggle", True)
+
+gen.add("exposure",                  double_t, 0, "exposure time value",    10000.0, 0.0,   500000.0 )
+gen.add("gain",                      double_t, 0, "gain value",             0.5,     0.0,   10.0     )
+gen.add("gamma",                     double_t, 0, "gamma value",            1.0,     0.0,   3.0       ) 
+gen.add("brightness",                double_t, 0, "brightness value",       100.0,   0.0,   100000.0  )
+
+# Auto Toggles
+gen.add("brightness_continuous",     bool_t,   0, "continuous brightness toggle", True )
+gen.add("exposure_auto",             bool_t,   0, "autoexposure toggle",          True ) 
+gen.add("gain_auto",                 bool_t,   0, "auto gain",                    True )
+gen.add("whitebalance_auto",         bool_t,   0, "auto white balance toggle",    True )
 
 exit(gen.generate(PACKAGE, "pylon_camera", "CameraSettings"))

--- a/cfg/CameraSettings.cfg
+++ b/cfg/CameraSettings.cfg
@@ -8,8 +8,8 @@ gen = ParameterGenerator()
 
 gen.add("exposure",                  double_t, 0, "exposure time value",    10000.0, 0.0,   500000.0 )
 gen.add("gain",                      double_t, 0, "gain value",             0.5,     0.0,   10.0     )
-gen.add("gamma",                     double_t, 0, "gamma value",            1.0,     0.0,   3.0       ) 
-gen.add("brightness",                double_t, 0, "brightness value",       100.0,   0.0,   100000.0  )
+gen.add("gamma",                     double_t, 0, "gamma value",            1.0,     0.0,   3.0      ) 
+gen.add("brightness",                double_t, 0, "brightness value",       100.0,   0.0,   100000.0 )
 
 # Auto Toggles
 gen.add("brightness_continuous",     bool_t,   0, "continuous brightness toggle", True )

--- a/cfg/CameraSettings.cfg
+++ b/cfg/CameraSettings.cfg
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+PACKAGE = "pylon_camera"
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+gen.add("whitebalance_auto", bool_t, 0, "auto white balance toggle", True)
+
+exit(gen.generate(PACKAGE, "pylon_camera", "CameraSettings"))

--- a/include/pylon_camera/internal/impl/pylon_camera_base.hpp
+++ b/include/pylon_camera/internal/impl/pylon_camera_base.hpp
@@ -233,15 +233,15 @@ void PylonCameraImpl<CameraTraitT>::enableContinuousAutoGain()
 }
 
 template <typename CameraTraitT>
-void PylonCameraImpl<CameraTraitT>::enableContinuousBalanceWhiteAuto()
+void PylonCameraImpl<CameraTraitT>::enableOnceBalanceWhiteAuto()
 {
     if ( GenApi::IsAvailable(cam_->BalanceWhiteAuto) )
     {
-        cam_->BalanceWhiteAuto.SetValue(BalanceWhiteAutoEnums::BalanceWhiteAuto_Continuous);
+        cam_->BalanceWhiteAuto.SetValue(BalanceWhiteAutoEnums::BalanceWhiteAuto_Once);
     }
     else
     {
-        ROS_ERROR_STREAM("Could not set BalanceWhiteAuto_Continuous mode");
+        ROS_ERROR_STREAM("Could not set BalanceWhiteAuto_Once mode");
     }
 
 }

--- a/include/pylon_camera/internal/impl/pylon_camera_base.hpp
+++ b/include/pylon_camera/internal/impl/pylon_camera_base.hpp
@@ -233,6 +233,20 @@ void PylonCameraImpl<CameraTraitT>::enableContinuousAutoGain()
 }
 
 template <typename CameraTraitT>
+void PylonCameraImpl<CameraTraitT>::enableContinuousBalanceWhiteAuto()
+{
+    if ( GenApi::IsAvailable(cam_->BalanceWhiteAuto) )
+    {
+        cam_->BalanceWhiteAuto.SetValue(BalanceWhiteAutoEnums::BalanceWhiteAuto_Continuous);
+    }
+    else
+    {
+        ROS_ERROR_STREAM("Could not set BalanceWhiteAuto_Continuous mode");
+    }
+
+}
+
+template <typename CameraTraitT>
 void PylonCameraImpl<CameraTraitT>::disableAllRunningAutoBrightessFunctions()
 {
     is_binary_exposure_search_running_ = false;

--- a/include/pylon_camera/internal/impl/pylon_camera_base.hpp
+++ b/include/pylon_camera/internal/impl/pylon_camera_base.hpp
@@ -233,15 +233,25 @@ void PylonCameraImpl<CameraTraitT>::enableContinuousAutoGain()
 }
 
 template <typename CameraTraitT>
-void PylonCameraImpl<CameraTraitT>::enableOnceBalanceWhiteAuto()
+bool PylonCameraImpl<CameraTraitT>::setBalanceWhiteAuto(bool balance_white_enable)
 {
     if ( GenApi::IsAvailable(cam_->BalanceWhiteAuto) )
     {
-        cam_->BalanceWhiteAuto.SetValue(BalanceWhiteAutoEnums::BalanceWhiteAuto_Once);
+        if (balance_white_enable)
+            {
+            cam_->BalanceWhiteAuto.SetValue(BalanceWhiteAutoEnums::BalanceWhiteAuto_Once);
+            }
+
+        else
+        {
+            cam_->BalanceWhiteAuto.SetValue(BalanceWhiteAutoEnums::BalanceWhiteAuto_Off);
+        }    
+        return true;
     }
     else
     {
         ROS_ERROR_STREAM("Could not set BalanceWhiteAuto_Once mode");
+        return false;
     }
 
 }

--- a/include/pylon_camera/internal/impl/pylon_camera_gige.hpp
+++ b/include/pylon_camera/internal/impl/pylon_camera_gige.hpp
@@ -53,6 +53,8 @@ struct GigECameraTrait
     typedef Basler_GigECameraParams::ShutterModeEnums ShutterModeEnums;
     typedef Basler_GigECamera::UserOutputSelectorEnums UserOutputSelectorEnums;
 
+    typedef Basler_GigECameraParams::BalanceWhiteAutoEnums BalanceWhiteAutoEnums;
+
     static inline AutoTargetBrightnessValueType convertBrightness(const int& value)
     {
         return value;

--- a/include/pylon_camera/internal/impl/pylon_camera_usb.hpp
+++ b/include/pylon_camera/internal/impl/pylon_camera_usb.hpp
@@ -53,6 +53,8 @@ struct USBCameraTrait
     typedef Basler_UsbCameraParams::ShutterModeEnums ShutterModeEnums;
     typedef Basler_UsbCameraParams::UserOutputSelectorEnums UserOutputSelectorEnums;
 
+    typedef Basler_UsbCameraParams::BalanceWhiteAutoEnums BalanceWhiteAutoEnums;
+    
     static inline AutoTargetBrightnessValueType convertBrightness(const int& value)
     {
         return value / 255.0;

--- a/include/pylon_camera/internal/pylon_camera.h
+++ b/include/pylon_camera/internal/pylon_camera.h
@@ -127,6 +127,8 @@ public:
 
     virtual void enableContinuousAutoGain();
 
+    virtual void enableContinuousBalanceWhiteAuto();
+
     virtual std::string typeName() const;
 
     virtual float exposureStep();
@@ -141,6 +143,9 @@ protected:
     typedef typename CameraTraitT::GainType GainType;
     typedef typename CameraTraitT::ShutterModeEnums ShutterModeEnums;
     typedef typename CameraTraitT::UserOutputSelectorEnums UserOutputSelectorEnums;
+
+
+    typedef typename CameraTraitT::BalanceWhiteAutoEnums BalanceWhiteAutoEnums;
 
     CBaslerInstantCameraT* cam_;
 

--- a/include/pylon_camera/internal/pylon_camera.h
+++ b/include/pylon_camera/internal/pylon_camera.h
@@ -127,7 +127,7 @@ public:
 
     virtual void enableContinuousAutoGain();
 
-    virtual void enableOnceBalanceWhiteAuto();
+    virtual bool setBalanceWhiteAuto( bool balance_white_enable );
 
     virtual std::string typeName() const;
 

--- a/include/pylon_camera/internal/pylon_camera.h
+++ b/include/pylon_camera/internal/pylon_camera.h
@@ -127,7 +127,7 @@ public:
 
     virtual void enableContinuousAutoGain();
 
-    virtual void enableContinuousBalanceWhiteAuto();
+    virtual void enableOnceBalanceWhiteAuto();
 
     virtual std::string typeName() const;
 

--- a/include/pylon_camera/pylon_camera.h
+++ b/include/pylon_camera/pylon_camera.h
@@ -322,6 +322,13 @@ public:
      */
     virtual void enableContinuousAutoGain() = 0;
 
+
+    /**
+    * Enables continuous auto white balance mode
+    */
+    virtual void enableContinuousBalanceWhiteAuto() = 0;
+
+
     /**
      * Get the camera type. Currently supported cameras are USB, DART and GigE
      * @return camera type as string

--- a/include/pylon_camera/pylon_camera.h
+++ b/include/pylon_camera/pylon_camera.h
@@ -326,7 +326,7 @@ public:
     /**
     * Enables continuous auto white balance mode
     */
-    virtual void enableOnceBalanceWhiteAuto() = 0;
+    virtual bool setBalanceWhiteAuto( bool balance_white_enable ) = 0;
 
 
     /**

--- a/include/pylon_camera/pylon_camera.h
+++ b/include/pylon_camera/pylon_camera.h
@@ -326,7 +326,7 @@ public:
     /**
     * Enables continuous auto white balance mode
     */
-    virtual void enableContinuousBalanceWhiteAuto() = 0;
+    virtual void enableOnceBalanceWhiteAuto() = 0;
 
 
     /**

--- a/include/pylon_camera/pylon_camera_node.h
+++ b/include/pylon_camera/pylon_camera_node.h
@@ -47,12 +47,6 @@
 #include <pylon_camera/CameraSettingsConfig.h>
 
 #include <camera_control_msgs/SetBool.h>
-#include <camera_control_msgs/SetBinning.h>
-#include <camera_control_msgs/SetBrightness.h>
-#include <camera_control_msgs/SetExposure.h>
-#include <camera_control_msgs/SetGain.h>
-#include <camera_control_msgs/SetGamma.h>
-#include <camera_control_msgs/SetSleeping.h>
 #include <camera_control_msgs/GrabImagesAction.h>
 
 namespace pylon_camera
@@ -121,9 +115,14 @@ protected:
 
     /**
     * Set parameters
-    *
     */
-    bool setParams();
+    pylon_camera::CameraSettingsConfig setParams(pylon_camera::CameraSettingsConfig config);
+
+    /**
+    * Conversion between dynamic recnfigure parameters and PylonCameraParameter class
+    */
+    void convertConfigParams(pylon_camera::CameraSettingsConfig &config);
+
 
     /**
      * Initializing of img_rect_pub_, grab_img_rect_as_ and the pinhole_model_,
@@ -179,29 +178,12 @@ protected:
                      size_t& reached_binning_y);
 
     /**
-     * Service callback for updating the cameras binning setting
-     * @param req request
-     * @param res response
-     * @return true on success
-     */
-    bool setBinningCallback(camera_control_msgs::SetBinning::Request &req,
-                            camera_control_msgs::SetBinning::Response &res);
-    /**
      * Update the exposure value on the camera
      * @param target_exposure the targeted exposure
      * @param reached_exposure the exposure that could be reached
      * @return true if the targeted exposure could be reached
      */
     bool setExposure(const float& target_exposure, float& reached_exposure);
-
-    /**
-     * Service callback for setting the exposure
-     * @param req request
-     * @param res response
-     * @return true on success
-     */
-    bool setExposureCallback(camera_control_msgs::SetExposure::Request &req,
-                             camera_control_msgs::SetExposure::Response &res);
 
     /**
      * Sets the target brightness which is the intensity-mean over all pixels.
@@ -223,15 +205,6 @@ protected:
                        const bool& gain_auto);
 
     /**
-     * Service callback for setting the brightness
-     * @param req request
-     * @param res response
-     * @return true on success
-     */
-    bool setBrightnessCallback(camera_control_msgs::SetBrightness::Request &req,
-                               camera_control_msgs::SetBrightness::Response &res);
-
-    /**
      * Update the gain from the camera to a target gain in percent
      * @param target_gain the targeted gain in percent
      * @param reached_gain the gain that could be reached
@@ -240,39 +213,12 @@ protected:
     bool setGain(const float& target_gain, float& reached_gain);
 
     /**
-     * Service callback for setting the desired gain in percent
-     * @param req request
-     * @param res response
-     * @return true on success
-     */
-    bool setGainCallback(camera_control_msgs::SetGain::Request &req,
-                         camera_control_msgs::SetGain::Response &res);
-
-    /**
      * Update the gamma from the camera to a target gamma correction value
      * @param target_gamma the targeted gamma
      * @param reached_gamma the gamma that could be reached
      * @return true if the targeted gamma could be reached
      */
     bool setGamma(const float& target_gamma, float& reached_gamma);
-
-    /**
-     * Service callback for setting the desired gamma correction value
-     * @param req request
-     * @param res response
-     * @return true on success
-     */
-    bool setGammaCallback(camera_control_msgs::SetGamma::Request &req,
-                         camera_control_msgs::SetGamma::Response &res);
-
-    /**
-     * Callback that puts the camera to sleep
-     * @param req request
-     * @param res response
-     * @return true on success
-     */
-    bool setSleepingCallback(camera_control_msgs::SetSleeping::Request &req,
-                             camera_control_msgs::SetSleeping::Response &res);
 
     /**
      * Returns true if the camera was put into sleep mode
@@ -343,13 +289,9 @@ protected:
     ros::NodeHandle* nh_image_;
     ros::Timer grab_image_timer_;
     
+    
     PylonCameraParameter pylon_camera_parameter_set_;
-    ros::ServiceServer set_binning_srv_;
-    ros::ServiceServer set_exposure_srv_;
-    ros::ServiceServer set_gain_srv_;
-    ros::ServiceServer set_gamma_srv_;
-    ros::ServiceServer set_brightness_srv_;
-    ros::ServiceServer set_sleeping_srv_;
+    pylon_camera::CameraSettingsConfig config_;
 
     dynamic_reconfigure::Server<pylon_camera::CameraSettingsConfig> cam_settings_server;
 

--- a/include/pylon_camera/pylon_camera_node.h
+++ b/include/pylon_camera/pylon_camera_node.h
@@ -114,6 +114,18 @@ protected:
     bool startGrabbing();
 
     /**
+    * Initialize camera, set initial parameters
+    *
+    */
+    bool initGrabbing();
+
+    /**
+    * Set parameters
+    *
+    */
+    bool setParams();
+
+    /**
      * Initializing of img_rect_pub_, grab_img_rect_as_ and the pinhole_model_,
      * in case that a vaid camera info has been set
      * @return
@@ -364,6 +376,8 @@ protected:
 
     bool is_sleeping_;
     boost::recursive_mutex grab_mutex_;
+
+    bool camera_initialized_;
 };
 
 }  // namespace pylon_camera

--- a/include/pylon_camera/pylon_camera_node.h
+++ b/include/pylon_camera/pylon_camera_node.h
@@ -40,9 +40,11 @@
 #include <image_transport/image_transport.h>
 #include <sensor_msgs/CameraInfo.h>
 #include <sensor_msgs/image_encodings.h>
+#include <dynamic_reconfigure/server.h>
 
 #include <pylon_camera/pylon_camera_parameter.h>
 #include <pylon_camera/pylon_camera.h>
+#include <pylon_camera/CameraSettingsConfig.h>
 
 #include <camera_control_msgs/SetBool.h>
 #include <camera_control_msgs/SetBinning.h>
@@ -90,6 +92,13 @@ public:
      * @return the camera frame.
      */
     const std::string& cameraFrame() const;
+
+    /**
+    * Callback for dynamic reconfigure parameters
+    */
+    void reconfigureCallback(pylon_camera::CameraSettingsConfig &config, 
+                            uint32_t level);
+
 
 protected:
     /**
@@ -317,6 +326,7 @@ protected:
      */
     bool waitForCamera(const ros::Duration& timeout) const;
 
+
     ros::NodeHandle* nh_private_;
     ros::NodeHandle* nh_image_;
     ros::Timer grab_image_timer_;
@@ -328,6 +338,9 @@ protected:
     ros::ServiceServer set_gamma_srv_;
     ros::ServiceServer set_brightness_srv_;
     ros::ServiceServer set_sleeping_srv_;
+
+    dynamic_reconfigure::Server<pylon_camera::CameraSettingsConfig> cam_settings_server;
+
     std::vector<ros::ServiceServer> set_user_output_srvs_;
 
     PylonCamera* pylon_camera_;

--- a/include/pylon_camera/pylon_camera_parameter.h
+++ b/include/pylon_camera/pylon_camera_parameter.h
@@ -220,6 +220,7 @@ public:
      */
     bool exposure_auto_;
     bool gain_auto_;
+    bool whitebalance_auto_;
     // #######################################################################
 
     /**

--- a/package.xml
+++ b/package.xml
@@ -33,9 +33,9 @@
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>roslaunch</build_depend>
-  <!--build_depend>std_srvs</build_depend-->
   <build_depend>roslint</build_depend>
   <build_depend>nodelet</build_depend>
+  <build_depend>dynamic_reconfigure</build_depend>
 
   <run_depend>actionlib</run_depend>
   <run_depend version_gte="0.0.14" version_lt="0.0.15">camera_control_msgs</run_depend>
@@ -47,8 +47,9 @@
   <run_depend>roscpp</run_depend>
   <run_depend>roslaunch</run_depend>
   <run_depend>sensor_msgs</run_depend>
-  <!--run_depend>std_srvs</run_depend-->
   <run_depend>nodelet</run_depend>
+  <run_depend>dynamic_reconfigure</run_depend>
+  <run_depend>roslint</run_depend>
 
   <export>
     <nodelet plugin="${prefix}/nodelet_plugins.xml" />

--- a/package.xml
+++ b/package.xml
@@ -47,9 +47,9 @@
   <run_depend>roscpp</run_depend>
   <run_depend>roslaunch</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>roslint</run_depend>
   <run_depend>nodelet</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
-  <run_depend>roslint</run_depend>
 
   <export>
     <nodelet plugin="${prefix}/nodelet_plugins.xml" />

--- a/src/pylon_camera/main.cpp
+++ b/src/pylon_camera/main.cpp
@@ -35,19 +35,34 @@
 #include <ros/ros.h>
 #include <boost/thread.hpp>
 #include <pylon_camera/pylon_camera_node.h>
+#include <pylon_camera/CameraSettingsConfig.h>
+
+void callback(pylon_camera::CameraSettingsConfig &config, uint32_t level) {
+	ROS_INFO_STREAM("dynamic_reconfigure callback");
+}
 
 
 int main(int argc, char **argv)
 {
     ros::init(argc, argv, "pylon_camera_node");
+
+
     ros::NodeHandle nh_private("~");
     ros::NodeHandle nh_image;
+
+	dynamic_reconfigure::Server<pylon_camera::CameraSettingsConfig> server;
+    dynamic_reconfigure::Server<pylon_camera::CameraSettingsConfig>::CallbackType f;
+
+    //f = boost::bind(&pylon_camera::PylonCameraNode::reconfigureCallback, _1, _2);
+    f = boost::bind(&callback, _1, _2);
+	server.setCallback(f);
 
     pylon_camera::PylonCameraNode pylon_camera_node(nh_private, nh_image);
 
     ROS_INFO_STREAM("Start image grabbing if node connects to topic with "
         << "a frame_rate of: " << pylon_camera_node.frameRate() << " Hz");
-
+   
+ 	
     ros::spin();
 
     ROS_INFO("Terminate PylonCameraNode");

--- a/src/pylon_camera/main.cpp
+++ b/src/pylon_camera/main.cpp
@@ -35,34 +35,19 @@
 #include <ros/ros.h>
 #include <boost/thread.hpp>
 #include <pylon_camera/pylon_camera_node.h>
-#include <pylon_camera/CameraSettingsConfig.h>
-
-void callback(pylon_camera::CameraSettingsConfig &config, uint32_t level) {
-	ROS_INFO_STREAM("dynamic_reconfigure callback");
-}
 
 
 int main(int argc, char **argv)
 {
     ros::init(argc, argv, "pylon_camera_node");
-
-
     ros::NodeHandle nh_private("~");
     ros::NodeHandle nh_image;
-
-	dynamic_reconfigure::Server<pylon_camera::CameraSettingsConfig> server;
-    dynamic_reconfigure::Server<pylon_camera::CameraSettingsConfig>::CallbackType f;
-
-    //f = boost::bind(&pylon_camera::PylonCameraNode::reconfigureCallback, _1, _2);
-    f = boost::bind(&callback, _1, _2);
-	server.setCallback(f);
 
     pylon_camera::PylonCameraNode pylon_camera_node(nh_private, nh_image);
 
     ROS_INFO_STREAM("Start image grabbing if node connects to topic with "
         << "a frame_rate of: " << pylon_camera_node.frameRate() << " Hz");
-   
- 	
+
     ros::spin();
 
     ROS_INFO("Terminate PylonCameraNode");

--- a/src/pylon_camera/pylon_camera_node.cpp
+++ b/src/pylon_camera/pylon_camera_node.cpp
@@ -93,11 +93,16 @@ void PylonCameraNode::init()
     // detected, the interface will reset them to the default values.
     // These parameters furthermore contain the intrinsic calibration matrices,
     // in case they are provided
+    
+    ROS_INFO_STREAM("Initializing parameters");
+
     pylon_camera_parameter_set_.readFromRosParameterServer(*nh_private_);
 
     // creating the target PylonCamera-Object with the specified
     // device_user_id, registering the Software-Trigger-Mode, starting the
     // communication with the device and enabling the desired startup-settings
+    
+
     if ( !initAndRegister() )
     {
         ros::shutdown();
@@ -327,11 +332,12 @@ bool PylonCameraNode::startGrabbing()
         }
     }
 
+    
     if (pylon_camera_parameter_set_.whitebalance_auto_ )
     {
-        pylon_camera_->enableContinuousBalanceWhiteAuto();
+        pylon_camera_->enableOnceBalanceWhiteAuto();
     }
-    
+     
 
     ROS_INFO_STREAM("Startup settings: "
             << "encoding = '" << pylon_camera_->currentROSEncoding() << "', "

--- a/src/pylon_camera/pylon_camera_node.cpp
+++ b/src/pylon_camera/pylon_camera_node.cpp
@@ -327,6 +327,12 @@ bool PylonCameraNode::startGrabbing()
         }
     }
 
+    if (pylon_camera_parameter_set_.whitebalance_auto_ )
+    {
+        pylon_camera_->enableContinuousBalanceWhiteAuto();
+    }
+    
+
     ROS_INFO_STREAM("Startup settings: "
             << "encoding = '" << pylon_camera_->currentROSEncoding() << "', "
             << "binning = [" << pylon_camera_->currentBinningX() << ", "

--- a/src/pylon_camera/pylon_camera_parameter.cpp
+++ b/src/pylon_camera/pylon_camera_parameter.cpp
@@ -58,6 +58,7 @@ PylonCameraParameter::PylonCameraParameter() :
         brightness_continuous_(false),
         exposure_auto_(true),
         gain_auto_(true),
+        whitebalance_auto_(true),
         // #########################
         exposure_search_timeout_(5.),
         auto_exp_upper_lim_(0.0),
@@ -71,6 +72,8 @@ PylonCameraParameter::~PylonCameraParameter()
 
 void PylonCameraParameter::readFromRosParameterServer(const ros::NodeHandle& nh)
 {
+    ROS_INFO_STREAM("Reading parameters from paramter server");
+
     nh.param<std::string>("camera_frame", camera_frame_, "pylon_camera");
 
     nh.param<std::string>("device_user_id", device_user_id_, "");
@@ -203,6 +206,12 @@ void PylonCameraParameter::readFromRosParameterServer(const ros::NodeHandle& nh)
                 std::cout << "gain is set to auto" << std::endl;
             }
         }
+    }
+
+    if ( nh.hasParam("whitebalance_auto") )
+    {
+        nh.getParam("whitebalance_auto", whitebalance_auto_);
+        std::cout << "continuous auto white balance set" << std::endl;
     }
     // ##########################
 

--- a/src/pylon_camera/pylon_camera_parameter.cpp
+++ b/src/pylon_camera/pylon_camera_parameter.cpp
@@ -36,7 +36,7 @@ namespace pylon_camera
 PylonCameraParameter::PylonCameraParameter() :
         camera_frame_("pylon_camera"),
         device_user_id_(""),
-        frame_rate_(5.0),
+        frame_rate_(30.0),
         camera_info_url_(""),
         image_encoding_(""),
         binning_x_(1),
@@ -44,27 +44,11 @@ PylonCameraParameter::PylonCameraParameter() :
         binning_x_given_(false),
         binning_y_given_(false),
         downsampling_factor_exp_search_(1),
-        // ##########################
-        //  image settings
-        // ##########################
-        exposure_(10000.0),
-        exposure_given_(false),
-        gain_(0.5),
-        gain_given_(false),
-        gamma_(1.0),
-        gamma_given_(false),
-        brightness_(100),
-        brightness_given_(false),
-        brightness_continuous_(false),
-        exposure_auto_(true),
-        gain_auto_(true),
-        whitebalance_auto_(true),
-        // #########################
         exposure_search_timeout_(5.),
         auto_exp_upper_lim_(0.0),
         mtu_size_(1500),
         inter_pkg_delay_(1000),
-        shutter_mode_(SM_DEFAULT)
+        shutter_mode_(SM_GLOBAL)
 {}
 
 PylonCameraParameter::~PylonCameraParameter()
@@ -72,7 +56,7 @@ PylonCameraParameter::~PylonCameraParameter()
 
 void PylonCameraParameter::readFromRosParameterServer(const ros::NodeHandle& nh)
 {
-    ROS_INFO_STREAM("Reading parameters from paramter server");
+    ROS_INFO_STREAM("Reading parameters from parameter server"); //probably don't need to do these anymore
 
     nh.param<std::string>("camera_frame", camera_frame_, "pylon_camera");
 
@@ -213,7 +197,7 @@ void PylonCameraParameter::readFromRosParameterServer(const ros::NodeHandle& nh)
     if ( nh.hasParam("whitebalance_auto") )
     {
         nh.getParam("whitebalance_auto", whitebalance_auto_);
-        std::cout << "continuous auto white balance set" << std::endl;
+        ROS_INFO_STREAM("Continuous auto white balance set");
     }
     
 
@@ -228,7 +212,7 @@ void PylonCameraParameter::readFromRosParameterServer(const ros::NodeHandle& nh)
     }
 
     if ( nh.hasParam("gige/inter_pkg_delay") )
-    {
+    { 
         nh.getParam("gige/inter_pkg_delay", inter_pkg_delay_);
     }
 

--- a/src/pylon_camera/pylon_camera_parameter.cpp
+++ b/src/pylon_camera/pylon_camera_parameter.cpp
@@ -45,7 +45,7 @@ PylonCameraParameter::PylonCameraParameter() :
         binning_y_given_(false),
         downsampling_factor_exp_search_(1),
         // ##########################
-        //  image intensity settings
+        //  image settings
         // ##########################
         exposure_(10000.0),
         exposure_given_(false),
@@ -62,7 +62,7 @@ PylonCameraParameter::PylonCameraParameter() :
         // #########################
         exposure_search_timeout_(5.),
         auto_exp_upper_lim_(0.0),
-        mtu_size_(3000),
+        mtu_size_(1500),
         inter_pkg_delay_(1000),
         shutter_mode_(SM_DEFAULT)
 {}

--- a/src/pylon_camera/pylon_camera_parameter.cpp
+++ b/src/pylon_camera/pylon_camera_parameter.cpp
@@ -208,11 +208,15 @@ void PylonCameraParameter::readFromRosParameterServer(const ros::NodeHandle& nh)
         }
     }
 
+
+    
     if ( nh.hasParam("whitebalance_auto") )
     {
         nh.getParam("whitebalance_auto", whitebalance_auto_);
         std::cout << "continuous auto white balance set" << std::endl;
     }
+    
+
     // ##########################
 
     nh.param<double>("exposure_search_timeout", exposure_search_timeout_, 5.);


### PR DESCRIPTION
Exposed current camera settings to dynamic reconfigure: 
- Gain (and auto gain toggle)
- Brightness (and auto brightness toggle -- neither seem to do anything to the image)
- Exposure (and auto exposure)
- Gamma
- Auto white balance enable

Other settings will need additional hooks into the Pylon API (custom white balance setttings, trigger settings, etc.)

Also set default MTU from 3000 to 1500 in case it's not set in the .launch file. 