### PR TITLE
Add Multi-Camera Functionality 

### DIFF
--- a/include/pylon_camera/pylon_camera.h
+++ b/include/pylon_camera/pylon_camera.h
@@ -56,8 +56,8 @@ public:
     static PylonCamera* create();
 
     /**
-     * Create a new PylonCamera instance based on the DeviceUserID of the camera.
-     * @param device_user_id Pylon DeviceUserID. If the string is empty, the
+     * Create a new PylonCamera instance based on the serial number of the camera.
+     * @param camera_serial Pylon cameraSerial. If the string is empty, the
      * first camera that could be found is returned.
      * @return new PylonCamera instance or NULL if the camera was not found.
      */

--- a/include/pylon_camera/pylon_camera_parameter.h
+++ b/include/pylon_camera/pylon_camera_parameter.h
@@ -69,6 +69,11 @@ public:
     const std::string& deviceUserID() const;
 
     /**
+    * Getter for camera_serial_ set from ros-parameter server
+    */
+    const std::string& cameraSerial() const;
+
+    /**
      * Getter for the string describing the shutter mode
      */
     std::string shutterModeString() const;
@@ -305,6 +310,12 @@ protected:
      * 'bayer_gbrg8', 'bayer_rggb8' and 'yuv422'
      */
     std::string image_encoding_;
+
+    /**
+    * Unique serial number for camera identification
+    */
+    std::string camera_serial_;
+
 };
 
 }  // namespace pylon_camera

--- a/src/pylon_camera/pylon_camera.cpp
+++ b/src/pylon_camera/pylon_camera.cpp
@@ -125,7 +125,7 @@ PylonCamera* createFromDevice(PYLON_CAM_TYPE cam_type, Pylon::IPylonDevice* devi
     }
 }
 
-PylonCamera* PylonCamera::create(const std::string& device_user_id_to_open)
+PylonCamera* PylonCamera::create(const std::string& camera_serial_to_open)
 {
     try
     {
@@ -145,25 +145,33 @@ PylonCamera* PylonCamera::create(const std::string& device_user_id_to_open)
         else
         {
             Pylon::DeviceInfoList_t::const_iterator it;
-            if ( device_user_id_to_open.empty() )
+            if ( camera_serial_to_open.empty() )
             {
-                ROS_INFO_STREAM("Found camera with DeviceUserID "
-                            << device_list.front().GetUserDefinedName() << ": "
+                ROS_INFO_STREAM("Found camera with Camera Serial:"
+                            << device_list.front().GetSerialNumber() << ": "
                             << device_list.front().GetModelName());
                 PYLON_CAM_TYPE cam_type = detectPylonCamType(device_list.front());
+                
+                
+                ROS_INFO_STREAM("All detected devices:");
+                for ( it = device_list.begin(); it != device_list.end(); ++it )
+                {
+                    ROS_INFO_STREAM(it->GetSerialNumber());
+                }
+
                 return createFromDevice(cam_type,
                                         tl_factory.CreateDevice(device_list.front()));
             }
             bool found_desired_device = false;
             for ( it = device_list.begin(); it != device_list.end(); ++it )
             {
-                std::string device_user_id_found(it->GetUserDefinedName());
-                if ( (0 == device_user_id_to_open.compare(device_user_id_found)) ||
-                     (device_user_id_to_open.length() < device_user_id_found.length() &&
-                     (0 == device_user_id_found.compare(device_user_id_found.length() -
-                                                         device_user_id_to_open.length(),
-                                                         device_user_id_to_open.length(),
-                                                         device_user_id_to_open) )
+                std::string camera_serial_found(it->GetSerialNumber());
+                if ( (0 == camera_serial_to_open.compare(camera_serial_found)) ||
+                     (camera_serial_to_open.length() < camera_serial_found.length() &&
+                     (0 == camera_serial_found.compare(camera_serial_found.length() -
+                                                         camera_serial_to_open.length(),
+                                                         camera_serial_to_open.length(),
+                                                         camera_serial_to_open) )
                      )
                    )
                 {
@@ -173,8 +181,8 @@ PylonCamera* PylonCamera::create(const std::string& device_user_id_to_open)
             }
             if ( found_desired_device )
             {
-                ROS_INFO_STREAM("Found the desired camera with DeviceUserID "
-                            << device_user_id_to_open << ": "
+                ROS_INFO_STREAM("Found the desired camera with serial "
+                            << camera_serial_to_open << ": "
                             << it->GetModelName());
                 PYLON_CAM_TYPE cam_type = detectPylonCamType(*it);
                 return createFromDevice(cam_type,
@@ -183,9 +191,7 @@ PylonCamera* PylonCamera::create(const std::string& device_user_id_to_open)
             else
             {
                 ROS_ERROR_STREAM("Couldn't find the camera, that matches the "
-                    << "given DeviceUserID: " << device_user_id_to_open << "!\r\n"
-                    << "Maybe it's wrong or has not yet been written to the "
-                    << "camera?!");
+                    << "given serial: " << camera_serial_to_open);
                 return nullptr;
             }
         }
@@ -193,7 +199,7 @@ PylonCamera* PylonCamera::create(const std::string& device_user_id_to_open)
     catch ( GenICam::GenericException &e )
     {
         ROS_ERROR_STREAM("An exception while opening the desired camera with "
-            << "DeviceUserID: " << device_user_id_to_open << " occurred: \r\n"
+            << "Serial: " << camera_serial_to_open << " occurred: \r\n"
             << e.GetDescription());
         return nullptr;
     }

--- a/src/pylon_camera/pylon_camera_node.cpp
+++ b/src/pylon_camera/pylon_camera_node.cpp
@@ -112,9 +112,9 @@ void PylonCameraNode::init()
 bool PylonCameraNode::initAndRegister()
 {
     pylon_camera_ = PylonCamera::create(
-                                    pylon_camera_parameter_set_.deviceUserID());
+                                    pylon_camera_parameter_set_.cameraSerial());
 
-    ROS_INFO_STREAM("deviceUserID " << pylon_camera_parameter_set_.deviceUserID());
+    ROS_INFO_STREAM("cameraSerial " << pylon_camera_parameter_set_.cameraSerial());
 
     if ( pylon_camera_ == nullptr )
     {
@@ -124,7 +124,7 @@ bool PylonCameraNode::initAndRegister()
         while ( ros::ok() && pylon_camera_ == nullptr )
         {
             pylon_camera_ = PylonCamera::create(
-                                    pylon_camera_parameter_set_.deviceUserID());
+                                    pylon_camera_parameter_set_.cameraSerial());
             if ( ros::Time::now() > end )
             {
                 ROS_WARN_STREAM("No camera present. Keep waiting ...");

--- a/src/pylon_camera/pylon_camera_parameter.cpp
+++ b/src/pylon_camera/pylon_camera_parameter.cpp
@@ -56,7 +56,7 @@ PylonCameraParameter::~PylonCameraParameter()
 
 void PylonCameraParameter::readFromRosParameterServer(const ros::NodeHandle& nh)
 {
-    ROS_INFO_STREAM("Reading parameters from parameter server"); //probably don't need to do these anymore
+    ROS_INFO_STREAM("Reading parameters from parameter server"); 
 
     nh.param<std::string>("camera_frame", camera_frame_, "pylon_camera");
 
@@ -72,6 +72,13 @@ void PylonCameraParameter::readFromRosParameterServer(const ros::NodeHandle& nh)
     {
         nh.getParam("camera_info_url", camera_info_url_);
     }
+
+    nh.param<std::string>("camera_serial", camera_serial_, "");
+    if ( nh.hasParam("camera_serial") )
+    {
+        nh.getParam("camera_serial", camera_serial_);
+    }
+
 
     binning_x_given_ = nh.hasParam("binning_x");
     if ( binning_x_given_ )
@@ -294,6 +301,11 @@ void PylonCameraParameter::validateParameterSet(const ros::NodeHandle& nh)
 const std::string& PylonCameraParameter::deviceUserID() const
 {
     return device_user_id_;
+}
+
+const std::string& PylonCameraParameter::cameraSerial() const
+{
+    return camera_serial_;
 }
 
 std::string PylonCameraParameter::shutterModeString() const


### PR DESCRIPTION
Identifies unique cameras using their serial numbers loaded as ROS
parameters. If none are given, the first enumerated camera is
initialized, and discovered camera serials are sent to ROS log output.

Note that this also removes the ability to use a user-defined ID to
enumerate cameras (since we weren't using it, and it requires another
utility to set those IDs).